### PR TITLE
Feature: allow user to be reminded again in future

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "user friendly electron auto updates",
   "main": "index.js",
   "scripts": {
-    "test": "xo && ava"
+    "test": "xo && ava",
+    "showcase": "electron showcase-dialogs.js"
   },
   "files": [
     "index.js"

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,10 @@ This package builds upon the great work done by `electron-builder` and `electron
 - Checks for updates at a regular interval (defaults to each hour)
 - Automatically downloads updates as they become available
 - Displays a dialog window and prompts the user to relaunch to update
+- Reminds users that an update is ready to be installed
 
 ## Coming soon
 
-- Remind users that an update is ready to be installed
 - Works with applications installed via snapcraft
 
 ## Usage

--- a/showcase-dialogs.js
+++ b/showcase-dialogs.js
@@ -1,0 +1,33 @@
+const {app, BrowserWindow} = require('electron');
+const {ElectronAutoUpdate} = require('.');
+
+app.whenReady().then(() => {
+	const win = new BrowserWindow({
+		width: 400,
+		height: 400,
+		webPreferences: {
+			nodeIntegration: true
+		}
+	});
+
+	const autoUpdate = new ElectronAutoUpdate({
+		checkFrequency: 3000,
+		electronUpdater: {
+			autoUpdater: {
+				quitAndInstall: () => {
+					app.quit();
+				}
+			}
+		}
+	});
+
+	setTimeout(() => {
+		autoUpdate.updateDownloaded();
+	}, 3000);
+
+	return win;
+});
+
+app.on('window-all-closed', () => {
+	app.quit();
+});


### PR DESCRIPTION
If the user chooses to not install the update immediately, there is now a checkbox, which is checked by default, to remind the user again at the same check frequency (defaults to 1 hour).

Also added a small showcase script so that the behaviour of the dialogs can be previewed.